### PR TITLE
Use more effective CSS statements

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,10 @@ Changelog
 3.0c2 (unreleased)
 ------------------
 
+- Use more effective CSS statements, prefixed with #content so that it allows
+  a general styling of elements such as lists.
+  [jone]
+
 - Register interfaces so that they can be toggled in manage_interfaces.
   [jone]
 

--- a/simplelayout/base/browser/resources/simplelayout.css
+++ b/simplelayout/base/browser/resources/simplelayout.css
@@ -64,15 +64,15 @@
     margin-top:0.9em;
 }
 /*no image*/
-.sl-img-no-image .sl-img-wrapper{
+#content .sl-img-no-image .sl-img-wrapper{
 	display:none;
 }
 
-.simplelayout-content .emptymarker {
+#content .simplelayout-content .emptymarker {
     min-height: 10em;
 }
 
-.simplelayout-content .sl-controls{
+#content .simplelayout-content .sl-controls{
     padding:0;
     padding-top:0.5em;
     display:none;
@@ -84,12 +84,12 @@
     direction:ltr;
 }
 
-.simplelayout-content .sl-controls img{
+#content .simplelayout-content .sl-controls img{
     padding:0;
     display:inline;
 }
 
-.simplelayout-content .sl-controls .sl-obj-actions{
+#content .simplelayout-content .sl-controls .sl-obj-actions{
     float:left;
 	font-weight:bold;
 	list-style-type:none;
@@ -97,8 +97,8 @@
 }
 
 
-#portal-columns .simplelayout-content .sl-controls .sl-obj-actions > li,
-#portal-columns .simplelayout-content .sl-controls .sl-obj-layouts > li{
+#content .simplelayout-content .sl-controls .sl-obj-actions > li,
+#content .simplelayout-content .sl-controls .sl-obj-layouts > li{
     display:block;
 	border: 1px solid #d3d3d3;
     background: #ededed; /*fallback for non-CSS3 browsers*/
@@ -112,12 +112,12 @@
     padding:0.5em;
 }
 
-.simplelayout-content .sl-controls .sl-actions-wrapper ul {
+#content .simplelayout-content .sl-controls .sl-actions-wrapper ul {
     margin-top:0;
 }
 
-.simplelayout-content .sl-controls .sl-obj-actions li:hover,
-.simplelayout-content .sl-controls .sl-obj-layouts li:hover{
+#content .simplelayout-content .sl-controls .sl-obj-actions li:hover,
+#content .simplelayout-content .sl-controls .sl-obj-layouts li:hover{
     background: #ededed; /*fallback for non-CSS3 browsers*/
     background: -webkit-gradient(linear, 0 0, 0 100%, from(#ededed) to(#f9f9f9)); /*old webkit*/
     background: -webkit-linear-gradient(#ededed, #f9f9f9); /*new webkit*/
@@ -128,18 +128,18 @@
     -pie-background: linear-gradient(#ededed, #f9f9f9); /*PIE*/
 }
 
-#portal-columns .simplelayout-content .sl-controls a{
+#content .simplelayout-content .sl-controls a{
     border:none;
 }
 
-.simplelayout-content .sl-controls .sl-obj-layouts{
+#content .simplelayout-content .sl-controls .sl-obj-layouts{
     float:left;
 	display:inline;
 	list-style-type:none;
 	list-style-image: none;
 }
 
-.simplelayout-content .sl-controls .document-action-foldercontents a {
+#content .simplelayout-content .sl-controls .document-action-foldercontents a {
   display: block;
   background-image: url(++resource++sl/icons/folder_icon.gif);
   background-repeat: no-repeat;
@@ -147,7 +147,7 @@
   height: 16px;
 }
 
-.simplelayout-content .sl-controls .document-action-dragme a {
+#content .simplelayout-content .sl-controls .document-action-dragme a {
   display: block;
   background-image: url(++resource++sl/icons/icon_move.png);
   background-repeat: no-repeat;
@@ -156,7 +156,7 @@
 }
 
 
-.simplelayout-content .sl-controls .document-action-factory dt a {
+#content .simplelayout-content .sl-controls .document-action-factory dt a {
     display: block;
     background-image: url(++resource++sl/icons/icon_add.png);
     background-repeat: no-repeat;
@@ -164,34 +164,34 @@
     height: 16px;
 }
 
-#portal-columns .simplelayout-content .sl-controls dl {
+#content .simplelayout-content .sl-controls dl {
     margin-bottom:0;
 }
 
-.simplelayout-content .sl-controls dl.actionMenu {
+#content .simplelayout-content .sl-controls dl.actionMenu {
     margin-left:0;
 }
 
-.simplelayout-content .sl-controls dl.actionMenu.deactivated dt,
-.simplelayout-content .sl-controls dl.actionMenu.activated dt a {
+#content .simplelayout-content .sl-controls dl.actionMenu.deactivated dt,
+#content .simplelayout-content .sl-controls dl.actionMenu.activated dt a {
     margin:0;
 }
 
-.simplelayout-content .sl-controls .sl-layout.active img{
+#content .simplelayout-content .sl-controls .sl-layout.active img{
 	background-color:orange;
 	border:1px solid orange;
 }
 
-.simplelayout-content .sl-controls .sl-layout a:hover img{
+#content .simplelayout-content .sl-controls .sl-layout a:hover img{
 	background-color:orange;
 	border:1px solid orange;
 }
-.simplelayout-content .sl-controls .sl-layout img{
+#content .simplelayout-content .sl-controls .sl-layout img{
     border:1px solid grey;
 	padding:0px;
 }
 
-#portal-columns .simplelayout-content .sl-controls .actionMenu .actionMenuContent {
+#content .simplelayout-content .sl-controls .actionMenu .actionMenuContent {
     float:left;
     margin:0;
     padding:0;
@@ -202,17 +202,17 @@
     border: 1px solid #d3d3d3;
 }
 
-#portal-columns .simplelayout-content .sl-controls .actionMenu .actionMenuContent ul {
+#content .simplelayout-content .sl-controls .actionMenu .actionMenuContent ul {
     margin:0;
 }
 
-#portal-columns .simplelayout-content .sl-controls .actionMenu .actionMenuContent li {
+#content .simplelayout-content .sl-controls .actionMenu .actionMenuContent li {
     margin-bottom:0;
     padding:0.3em;
     list-style: none;
 }
 
-.simplelayout-content .sl-controls .actionMenu .actionMenuContent ul {
+#content .simplelayout-content .sl-controls .actionMenu .actionMenuContent ul {
     background-color:transparent;
     border-color:#8CACBB;
 }
@@ -295,13 +295,13 @@ clear:both;
     height:0.1%;
 }
 
-.simplelayout-content.two-columns-design .twocolumn {
+#content .simplelayout-content.two-columns-design .twocolumn {
     width:49.7%;
     float:left;
 }
 
-.sl-toggle-edit-bar-wrapper,
-.sl-toggle-edit-bar-wrapper:hover {
+#content .sl-toggle-edit-bar-wrapper,
+content .sl-toggle-edit-bar-wrapper:hover {
 	border: 1px solid #d3d3d3;
     background: #ededed; /*fallback for non-CSS3 browsers*/
     background: -webkit-gradient(linear, 0 0, 0 100%, from(#f9f9f9) to(#ededed)); /*old webkit*/
@@ -316,7 +316,7 @@ clear:both;
     float:right;
 }
 
-.sl-toggle-edit-bar-wrapper:hover {
+#content .sl-toggle-edit-bar-wrapper:hover {
     background: #ededed; /*fallback for non-CSS3 browsers*/
     background: -webkit-gradient(linear, 0 0, 0 100%, from(#ededed) to(#f9f9f9)); /*old webkit*/
     background: -webkit-linear-gradient(#ededed, #f9f9f9); /*new webkit*/
@@ -327,19 +327,19 @@ clear:both;
     -pie-background: linear-gradient(#ededed, #f9f9f9); /*PIE*/
 }
 
-.sl-toggle-edit-bar {
+#content .sl-toggle-edit-bar {
     left: -0.2em;
     top: 0.6em;
     position:relative;
 }
 
-.sl-actions-wrapper {
+#content .sl-actions-wrapper {
     float:right;
     position: fixed;
     left: -1000px;
 }
 
-.showSimplelayoutControls {
+#content .showSimplelayoutControls {
     position: relative;
     left:0;
 }


### PR DESCRIPTION
Some diazo themes use general styling, such as:

``` css
#content ul {
    list-style-type: disc;
    margin-left: 2em;
}
```

This breaks the simplelayout menu, since it is prefixed with `#content`.
In order to make the simplelayout menu stylings stronger, I've prefixed the most important statements in `simplelayout.css` with `#content` too, so that they will be used even when a later theme css styles `#content ul`.

I've also removed the use of `#portal-columns`, using `#content` instead, since the `#portal-columns` may not be there in a diazo based theme. It is more common to use `#content`.
