### PR TITLE
Copy / Move: intelligent slot reset

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0c4 (unreleased)
 ------------------
 
+- Do not reset block layout when copying / moving the container.
+  [jone]
+
 - Fixed bug in function to get factory menu; return menu instead of True.
   [Julian Infanger]
 

--- a/simplelayout/base/events.py
+++ b/simplelayout/base/events.py
@@ -166,6 +166,10 @@ def blockMoved(obj, event):
     reindexContainer(obj, event, parent=event.oldParent)
     reindexContainer(obj, event, parent=event.newParent)
 
+    if obj != event.object:
+        # Moving the parent, so we do not reset the layout.
+        return
+
     # remove slote interfaces
     for key, iface in SLOT_INTERFACES_MAP.items():
         if iface.providedBy(obj):


### PR DESCRIPTION
When copying or moving a SL-Container, all SL-Blocks are currently reset to slot A.

The blocks should only be changed when copying or moving the slot itself, but not when copying / moving the container.
