### PR TITLE
Only set a min-height on empty slots if you are dragging a block.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0c4 (unreleased)
 ------------------
 
+- Only set a min-height on empty slots if you are dragging a block.
+  [Julian Infanger]
+
 - Fix css selector for empty dropzoneportlet.
   [mathias.leimgruber]
 

--- a/simplelayout/base/browser/resources/simplelayout.css
+++ b/simplelayout/base/browser/resources/simplelayout.css
@@ -68,8 +68,8 @@
 	display:none;
 }
 
-.documentEditable #content .simplelayout-content .emptymarker,
-.simplelayoutDropZonePortlet .simplelayout-content.editable .emptymarker {
+.documentEditable #content .simplelayout-content .emptymarker.highlightBorder,
+.simplelayoutDropZonePortlet .simplelayout-content.editable .emptymarker.highlightBorder {
     min-height: 10em;
 }
 


### PR DESCRIPTION
@maethu 
