### PR TITLE
Dexterity Support

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0c4 (unreleased)
 ------------------
 
+- Add simplelayout capable behavior for sl dexterity containers.
+  [jone]
+
 - Simplelayout should not change the styling of default plone classes.
   [Julian Infanger]
 

--- a/simplelayout/base/configure.zcml
+++ b/simplelayout/base/configure.zcml
@@ -375,4 +375,8 @@
 
     <include package=".upgrade" />
 
+    <include
+        zcml:condition="installed plone.app.dexterity"
+        file="dexterity.zcml" />
+
 </configure>

--- a/simplelayout/base/dexterity.zcml
+++ b/simplelayout/base/dexterity.zcml
@@ -1,0 +1,29 @@
+<configure
+    xmlns="http://namespaces.zope.org/zope"
+    xmlns:plone="http://namespaces.plone.org/plone"
+    xmlns:zcml="http://namespaces.zope.org/zcml"
+    i18n_domain="simplelayout">
+
+    <include package="plone.behavior" file="meta.zcml" />
+
+    <plone:behavior
+        title="Simplelayout capable container"
+        description="Enables simplelayout on the container."
+        provides="simplelayout.base.interfaces.ISimpleLayoutCapable"
+        for="plone.dexterity.interfaces.IDexterityContent"
+        />
+
+    <subscriber
+        for="simplelayout.base.interfaces.ISimpleLayoutCapable
+             zope.lifecycleevent.interfaces.IObjectCreatedEvent"
+        handler=".events.setDefaultDesignInterface"
+        />
+
+    <adapter
+        zcml:condition="installed collective.dexteritytextindexer"
+        factory=".indexer.DexteritySearchableBlockTextExtender"
+        provides="collective.dexteritytextindexer.IDynamicTextIndexExtender"
+        name="ISimpleLayoutCapable"
+        />
+
+</configure>

--- a/simplelayout/base/indexer.py
+++ b/simplelayout/base/indexer.py
@@ -1,13 +1,20 @@
-from simplelayout.base.config import BLOCK_INTERFACES
-from zope.component import getUtility
-from simplelayout.base.interfaces import ISlUtils
 from plone.indexer import indexer
+from simplelayout.base.config import BLOCK_INTERFACES
 from simplelayout.base.interfaces import ISimpleLayoutCapable
+from simplelayout.base.interfaces import ISlUtils
+from zope.component import adapts
+from zope.component import getUtility
 
 
 @indexer(ISimpleLayoutCapable)
 def SearchableText(obj):
     searchable_text = obj.SearchableText()
+    searchable_text += get_blocks_searchable_text(obj)
+    return searchable_text
+
+
+def get_blocks_searchable_text(obj):
+    searchable_text = ''
     # only index sub-blocks if blockworkflow is not enabled
     conf = getUtility(ISlUtils, name='simplelayout.utils')
     if not conf.isBlockWorkflowEnabled():
@@ -22,3 +29,13 @@ def SearchableText(obj):
         if isinstance(searchable_text, unicode):
             searchable_text = searchable_text.encode('utf8')
     return searchable_text
+
+
+class DexteritySearchableBlockTextExtender(object):
+    adapts(ISimpleLayoutCapable)
+
+    def __init__(self, context):
+        self.context = context
+
+    def __call__(self):
+        return get_blocks_searchable_text(self.context)


### PR DESCRIPTION
- Add simplelayout capable behavior for sl dexterity containers.
- Refactor block searchable text indexer so that it can be reused with `collective.dexteritytextindexer`
- Non-obtrusive: does not require dexterity, just enables itself when dexterity is there.

\cc @maethu 
