### PR TITLE
Fixed problem on draging blocks in simplelayout two column layout.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixed problem on draging blocks in simplelayout two column layout.
+  [Julian Infanger]
 
 
 3.0.2 (2013-05-31)

--- a/simplelayout/base/browser/resources/simplelayout.css
+++ b/simplelayout/base/browser/resources/simplelayout.css
@@ -238,6 +238,7 @@ div.documentActions ul.simplelayout{
 
 .highlightBorder {
     border:1px dotted #8CACBB;
+    margin: -1px;
     padding: 0px;
 }
 


### PR DESCRIPTION
![proof](https://f.cloud.github.com/assets/157533/708258/a8eafbdc-de3f-11e2-8b99-d5874da0dea9.png)
