### PR TITLE
The sizes in simplelayout controls should not be affected by font-size.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
+- The sizes in simplelayout controls should not be affected by font-size.
+  [Julian Infanger]
+
 - Fixed problem on draging blocks in simplelayout two column layout.
   [Julian Infanger]
 

--- a/simplelayout/base/browser/resources/simplelayout.css
+++ b/simplelayout/base/browser/resources/simplelayout.css
@@ -84,6 +84,7 @@
     margin-bottom: -4em;
     z-index: 2;
     direction:ltr;
+    font-size: 12px;
 }
 
 #content .simplelayout-content .sl-controls img,


### PR DESCRIPTION
The paddings in simplelayout controls are optimized for a 12px font-size.
If you use a bigger font for example the buttons padding change.
We can always use 12px font-size for sl-controls because there is no text inside them. 

![bildschirmfoto-2013-07-24-um-09 46 35](https://f.cloud.github.com/assets/157533/847234/c1108d46-f436-11e2-8387-c7cd4d54af1a.png)

@jone @maethu 
