### PR TITLE
don't substract controlheights anymore & use divs for visual clear

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 3.0.3 (unreleased)
 ------------------
 
+- Fix dragndrop for two column layout.
+  [tschanzt]
+
 - The sizes in simplelayout controls should not be affected by font-size.
   [Julian Infanger]
 

--- a/simplelayout/base/browser/resources/simplelayout.js
+++ b/simplelayout/base/browser/resources/simplelayout.js
@@ -20,16 +20,15 @@ simplelayout.alignBlockToGridAction = function(){
             left_block_content.css('height','');
             // calc block height, to prevent problems with float, we take the overallblock height
             // includes the controls area, then overallblockheight - controlsheight
-            left_height = $(left_block).height() - left_block_controls.height();
+            left_height = $(left_block).height();
         }
 
         if  (typeof(right_block) != 'undefined'){
             var right_block_content = $('.simplelayout-block-wrapper',right_block);
             var right_block_controls = $('.sl-controls',right_block);
             right_block_content.css('height','');
-            right_height = $(right_block).height() - right_block_controls.height();
+            right_height = $(right_block).height();
         }
-
 
 
         if ((left_height > 0 && right_height > 0) && (parseInt(simplelayout.align_to_grid)==1)) {
@@ -53,7 +52,7 @@ simplelayout.alignBlockToGridAction = function(){
 
     //reset all others (if block moved to onecolumn slot)
     $('.onecolumn .BlockOverallWrapper').css('height','');
-    $.post(getBaseUrl()+'block_manipulation/setBlockHeights',{'uids:list':all_uids,'left:list':all_left_blocks, 'right:list':all_right_blocks}, function(data){});
+    $.post(getBaseUrl()+'block_manipulation/setBlockHeights',{'uids:list':all_uids,'left:list':all_left_blocks, 'right:list':all_right_blocks});
 };
 
 

--- a/simplelayout/base/viewlets/listing_two_columns.pt
+++ b/simplelayout/base/viewlets/listing_two_columns.pt
@@ -9,7 +9,7 @@
 			     class=""
 			     tal:content="structure python:view.renderBlockProvider(result)">block</div>
 		</tal:repeat>
-        <span class="visualClear"><!-- --></span>
+        <div class="visualClear"><!-- --></div>
      </div>
 
     <div id="slotB" tal:attributes="class python:resultsright and 'twocolumn right' or 'twocolumn right emptymarker'">
@@ -21,7 +21,7 @@
 			     class=""
 			     tal:content="structure python:view.renderBlockProvider(result)">block</div>
 		</tal:repeat>
-        <span class="visualClear"><!-- --></span>
+        <div class="visualClear"><!-- --></div>
      </div>
-	<span class="visualClear"><!-- --></span>
+	<div class="visualClear"><!-- --></div>
 </div>

--- a/simplelayout/base/viewlets/listing_two_columns_one_on_top.pt
+++ b/simplelayout/base/viewlets/listing_two_columns_one_on_top.pt
@@ -10,7 +10,7 @@
 			     class=""
 			     tal:content="structure python:view.renderBlockProvider(result)">block</div>
 		</tal:repeat>
-        <span class="visualClear"><!-- --></span>
+        <div class="visualClear"><!-- --></div>
      </div>
 
     <div id="slotB" tal:attributes="class python:resultsleft and 'twocolumn left' or 'twocolumn left emptymarker'">
@@ -22,7 +22,7 @@
 			     class=""
 			     tal:content="structure python:view.renderBlockProvider(result)">block</div>
 		</tal:repeat>
-        <span class="visualClear"><!-- --></span>
+        <div class="visualClear"><!-- --></div>
      </div>
 
     <div id="slotC" class="twocolumn right" tal:attributes="class python:resultsright and 'twocolumn right' or 'twocolumn right emptymarker'">
@@ -35,5 +35,5 @@
 			     tal:content="structure python:view.renderBlockProvider(result)">block</div>
 		</tal:repeat>
      </div>
-	<span class="visualClear"><!-- --></span>
+	<div class="visualClear"><!-- --></div>
 </div>

--- a/simplelayout/base/views.py
+++ b/simplelayout/base/views.py
@@ -224,7 +224,7 @@ class BlockManipulation(BrowserView):
         # XXX:
         # Don't understand, why the varname:list, will shown as
         # varname:list[]
-        # I just make this work, but i need to be fixed
+        # I just make this work, but it needs to be fixed
 
         uids = self.request.get('uids:list[]', [])
         # In case if only one block is available
@@ -250,5 +250,4 @@ class BlockManipulation(BrowserView):
             else:
                 #remove heights
                 blockconf.block_height = None
-
         return 1


### PR DESCRIPTION
@jone this should fix the simplelayout multicolumn views and make dragndrop possible again.
