### PR TITLE
Set width to 100% for image blocks.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,8 @@ Changelog
 4.0.5 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Set image block width to full width.
+  [Kevin Bieri]
 
 
 4.0.4 (2015-02-23)

--- a/simplelayout/base/browser/resources/simplelayout.css
+++ b/simplelayout/base/browser/resources/simplelayout.css
@@ -4,6 +4,10 @@
     position:relative;
 }
 
+.BlockOverallWrapper.image {
+    width: 100%;
+}
+
 .simplelayout-block-wrapper{
     margin: 0px;
     padding: 0px;


### PR DESCRIPTION
In IE and Firefox the BlockOverallWrapper did not adjust to max width of its parent with width auto.
With width 100% the width is adjusted to full width of its parent.